### PR TITLE
Fused softmax fix

### DIFF
--- a/05_fused_softmax/fused_softmax.py
+++ b/05_fused_softmax/fused_softmax.py
@@ -237,6 +237,8 @@ def softmax(x):
         x, y,
         x.stride(0), y.stride(0),
         n_rows, n_cols,
+        BLOCK_SIZE,
+        num_stages
     )
     return y
 


### PR DESCRIPTION
The current script yields the following error. 

> Traceback (most recent call last):                                     
>   File "/workspace/triton_docs_tutorials/05_fused_softmax/fused_softmax
> .py", line 301, in <module>                                            
>     test_softmax_kernel(size=(1823, 781))                              
>   File "/workspace/triton_docs_tutorials/05_fused_softmax/fused_softmax
> .py", line 257, in test_softmax_kernel                                 
>     z_tri = softmax(x)                                                 
>             ^^^^^^^^^^                                                 
>   File "/workspace/triton_docs_tutorials/05_fused_softmax/fused_softmax
> .py", line 236, in softmax                                             
>     kernel[grid](                                                      
>   File "/venv/main/lib/python3.12/site-packages/triton/compiler/compile
> r.py", line 438, in runner         
>     self.run(grid[0], grid[1], grid[2], stream, self.function, self.pac
> ked_metadata, launch_metadata,     
>   File "/venv/main/lib/python3.12/site-packages/triton/backends/nvidia/
> driver.py", line 529, in __call__  
>     self.launch(gridX, gridY, gridZ, stream, function, self.launch_coop
> erative_grid, global_scratch, *args)                                   
> TypeError: function takes exactly 19 arguments (17 given)  

Upon inspecting the Triton source, it appears they now only mock positional arguments on warmup. IMO this is a bug, but it has a simple fix which is to add the constexpr arguments explicitly as positional arguments

Tested on RTX 5060 Ti.